### PR TITLE
JS Keywords darken, colors: -slate-light-saturated, Shadow DOM, Deprecation Cop fixes

### DIFF
--- a/index.less
+++ b/index.less
@@ -107,7 +107,7 @@
 
   .variable.parameter {
     font-style: italic;
-    color: #FD971F;
+    color: @syntax-color-orange;
   }
 
   .entity.name.tag {
@@ -207,3 +207,4 @@
 }
 
 @import './stylesheets/languages/php';
+@import './stylesheets/languages/js';

--- a/index.less
+++ b/index.less
@@ -1,11 +1,11 @@
-@import 'syntax-variables';
+@import 'stylesheets/syntax-variables';
 
-.editor-colors {
-  background-color: @syntax-background-color;
-  color: @syntax-text-color;
+.editor-colors, :host {
+    background-color: @syntax-background-color;
+    color: @syntax-text-color;
 }
 
-.editor {
+.editor, :host {
   .invisible-character {
     color: @syntax-invisible-character-color;
   }
@@ -185,7 +185,6 @@
       }
     }
   }
-
 }
 
 // Minimap Styling
@@ -202,9 +201,10 @@
 
 // Hide file-icons in tabs
 
-.pane ul.tab-bar li.tab .title:before {
+atom-pane ul.tab-bar li.tab .title:before {
   display: none;
 }
 
 @import './stylesheets/languages/php';
 @import './stylesheets/languages/js';
+@import './stylesheets/languages/mustache';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proton-framer",
   "theme": "syntax",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "description": "A Proton Light UI syntax theme inspired by Framer JS.",
   "repository": {

--- a/stylesheets/languages/js.less
+++ b/stylesheets/languages/js.less
@@ -1,0 +1,8 @@
+.editor[data-grammar~="js"] {
+
+  .keyword {
+    &.control {
+      color: @syntax-color-slate-light-saturated;
+    }
+  }
+}

--- a/stylesheets/languages/js.less
+++ b/stylesheets/languages/js.less
@@ -1,8 +1,7 @@
-.editor[data-grammar~="js"] {
-
-  .keyword {
-    &.control {
-      color: @syntax-color-slate-light-saturated;
+.editor[data-grammar~="js"], :host {
+    .keyword {
+      &.control {
+        color: @syntax-color-slate-light-saturated;
+      }
     }
-  }
 }

--- a/stylesheets/languages/mustache.less
+++ b/stylesheets/languages/mustache.less
@@ -1,0 +1,2 @@
+.editor[data-grammar~="mustache"], :host {
+}

--- a/stylesheets/languages/php.less
+++ b/stylesheets/languages/php.less
@@ -1,4 +1,4 @@
-.editor[data-grammar~="php"] {
+.editor[data-grammar~="php"], :host {
 
   .keyword {
     &.namespace, &.use, &.use-as, &.new {

--- a/stylesheets/languages/php.less
+++ b/stylesheets/languages/php.less
@@ -32,7 +32,6 @@
   }
 
   .support.function, .meta.function-call {
-    color: darken(saturate(@syntax-color-slate-light, 10%), 15%);
-    /* color: lighten(@syntax-color-purple, 12%); */
+    color: @syntax-color-slate-light-saturated;
   }
 }

--- a/stylesheets/syntax-variables.less
+++ b/stylesheets/syntax-variables.less
@@ -1,6 +1,7 @@
 // Custom colors
 @syntax-color-slate       : #788D9E;
 @syntax-color-slate-light : #A4BDD1;
+@syntax-color-slate-light-saturated: darken(saturate(@syntax-color-slate-light, 10%), 15%); 
 @syntax-color-green       : #6ED300;
 @syntax-color-orange      : #FF9740;
 @syntax-color-blue        : #5bc1f0;

--- a/stylesheets/syntax-variables.less
+++ b/stylesheets/syntax-variables.less
@@ -1,7 +1,7 @@
 // Custom colors
 @syntax-color-slate       : #788D9E;
 @syntax-color-slate-light : #A4BDD1;
-@syntax-color-slate-light-saturated: darken(saturate(@syntax-color-slate-light, 10%), 15%); 
+@syntax-color-slate-light-saturated: darken(saturate(@syntax-color-slate-light, 10%), 15%);
 @syntax-color-green       : #6ED300;
 @syntax-color-orange      : #FF9740;
 @syntax-color-blue        : #5bc1f0;


### PR DESCRIPTION
Darkened up the keywords in JS for better visibility, fixed Deprecation Cop issues, Added Shadow DOM compatibility (0.166+), added some colors.
